### PR TITLE
YAML files containing boolean or integer values cause an error

### DIFF
--- a/fixtures/boolean.yml
+++ b/fixtures/boolean.yml
@@ -1,0 +1,2 @@
+---
+var_from_yaml: true

--- a/fixtures/integer.yml
+++ b/fixtures/integer.yml
@@ -1,0 +1,2 @@
+---
+var_from_yaml: 42

--- a/yml2env.go
+++ b/yml2env.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/EngineerBetter/yml2env/env"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/EngineerBetter/yml2env/env"
+	"gopkg.in/yaml.v2"
 )
 
 var usage = "yml2env <YAML file> <command>"
@@ -70,12 +72,22 @@ func parseYaml(bytes []byte) yaml.MapSlice {
 	return vars
 }
 
+func valueToString(item yaml.MapItem) yaml.MapItem {
+	if value, ok := item.Value.(bool); ok {
+		item.Value = strconv.FormatBool(value)
+	} else if value, ok := item.Value.(int); ok {
+		item.Value = strconv.Itoa(value)
+	}
+	return item
+}
+
 func addUppercaseKeysToEnv(mapSlice yaml.MapSlice, envVars []string) []string {
 	for i := 0; i < len(mapSlice); i++ {
 		item := mapSlice[i]
 
 		if key, ok := item.Key.(string); ok {
 			key := strings.ToUpper(key)
+			item = valueToString(item)
 			if value, ok := item.Value.(string); ok {
 				envVars = env.Set(key, value, envVars)
 			} else {

--- a/yml2env_test.go
+++ b/yml2env_test.go
@@ -55,4 +55,20 @@ var _ = Describe("yml2env", func() {
 		Eventually(session).Should(Exit(0))
 		Ω(session).Should(Say("value from yaml"))
 	})
+
+	It("invokes the given command passing boolean env vars from the YAML file", func() {
+		command := exec.Command(cliPath, "fixtures/boolean.yml", "fixtures/script.sh")
+		session, err := Start(command, GinkgoWriter, GinkgoWriter)
+		Ω(err).ShouldNot(HaveOccurred())
+		Eventually(session).Should(Exit(0))
+		Ω(session).Should(Say("true"))
+	})
+
+	It("invokes the given command passing integer env vars from the YAML file", func() {
+		command := exec.Command(cliPath, "fixtures/integer.yml", "fixtures/script.sh")
+		session, err := Start(command, GinkgoWriter, GinkgoWriter)
+		Ω(err).ShouldNot(HaveOccurred())
+		Eventually(session).Should(Exit(0))
+		Ω(session).Should(Say("42"))
+	})
 })


### PR DESCRIPTION
Currently, invoking `yml2env` with a yaml file containing non-string values will result in an error.  For example, using a yaml file containing `var: true` results in:

```sh
$ yml2env boolean.yml script.sh
YAML invalid
```

This is happening because `addUppercaseKeysToEnv` specifically checks that the values from the parsed yaml are strings.  My understanding is that all variables in bash are implicitly strings and Concourse's fly CLI [wraps non-string variables in quotes](https://github.com/concourse/concourse/issues/360) anyway.

I've implemented a solution where boolean and integer values are converted into strings before getting to the type assertion.